### PR TITLE
Added possibility to bind ng-drag-scroll to DOM elements

### DIFF
--- a/example-multiple-scrolls.html
+++ b/example-multiple-scrolls.html
@@ -134,7 +134,7 @@
 
       <hr/>
       <div class="draggable-zones-container">
-            <div ng-drop="true" ng-drop-success="onDropComplete1($data,$event)">
+            <div ng-drop="true" ng-drop-success="onDropComplete1($data,$event)" ng-drag-enter="onDragEnter1($data, $event)" ng-drag-leave="onDragLeave1($data, $event)">
                 <span class="title">Drop area #1</span>
                 <div ng-repeat="obj in droppedObjects1" class="redbox {{obj.group}}" ng-drag="true" ng-drag-data="obj" ng-drag-success="onDragSuccess1($data,$event)"  ng-drag-clone-group="{{obj.group}}"  ng-drag-scroll="true" scroll-element=".draggable-zones-container">
                     {{obj.name}}
@@ -170,8 +170,14 @@
       </div>
       <hr>
 
-      <div ng-drag-clone="" >
-          {{clonedData.name}}
+      <div ng-drag-clone="" ng-drag-clone-copy-html=".clone_container">
+          <p class="clone_container">
+            {{clonedData.name}}
+          </p>
+      </div>
+
+      <div class="clone_container bis">
+
       </div>
 
       <div ng-drag-clone="" ng-drag-clone-copy-class="true" ng-drag-clone-copy-html="false" ng-drag-clone-group="special">
@@ -207,6 +213,15 @@
                 $scope.droppedObjects1.splice(index, 1);
             }
         }
+
+        $scope.onDragEnter1=function($data, $event){
+            console.log("onDragEnter1", $data, $event);
+        }
+
+        $scope.onDragLeave1=function(drop,drag){
+            console.log("onDragLeave1", drop, drag);
+        }
+
         $scope.onDragSuccess2=function(data,evt){
             var index = $scope.droppedObjects2.indexOf(data);
             if (index > -1) {

--- a/example-multiple-scrolls.html
+++ b/example-multiple-scrolls.html
@@ -15,17 +15,19 @@
         -ms-user-select: none;
         user-select: none;
     }
-    [ng-drag]{
+    .redbox{
         width: 100px;
         height: 100px;
-        background: rgba(255,0,0, 0.5);
+        background: rgb(250,10,10);
         color:white;
         text-align: center;
         padding-top:40px;
         display: inline-block;
-        margin::0px 10px;
         cursor: move;
+        margin-right: 10px;
+        margin-bottom: 10px;
     }
+
     ul.draggable-objects:after{
         display: block;
         content:"";
@@ -39,18 +41,38 @@
     }
 
     .draggable-objects li{
+        list-style: none;
         float:left;
-        display: block;
-        width: 120px;
-        height:100px;
-        margin-bottom: 10px;
     }
-    [ng-drag].drag-over{
+
+    .redbox.special
+    {
+      width: 200px;
+      background-color: #00FF00;
+    }
+
+    .redbox.special.dragging
+    {
+        padding-top: 5px;
+    }
+
+    .redbox.drag-over{
         border:solid 1px red;
     }
-    [ng-drag].dragging{
-        opacity: 0.5;
+    .redbox.dragging{
+        opacity: 0.7;
     }
+
+    .redbox.dragging.drag-over
+    {
+      opacity: 1;
+    }
+
+    [ng-drop] .redbox
+    {
+      display: inline-block;
+    }
+
     [ng-drop]{
         background: rgba(0,255,0, 0.5);
         text-align: center;
@@ -104,7 +126,9 @@
       <div class="space"></div>
         <ul class="draggable-objects">
             <li  ng-repeat="obj in draggableObjects" >
-                <div ng-drag="true" ng-drag-data="obj" data-allow-transform="true" ng-drag-scroll="true" scroll-element=".draggable-zones-container"> {{obj.name}} </div>
+                <div class="redbox {{obj.group}}" ng-drag-clone-group="{{obj.group}}" ng-drag-clone-copy-class="true" ng-drag-clone-add-class="test" ng-drag="true"  ng-drag-clone-group="{{obj.group}}" ng-drag-data="obj" data-allow-transform="true" ng-drag-scroll="true" scroll-element=".draggable-zones-container">
+                   {{obj.name}}
+                 </div>
             </li>
         </ul>
 
@@ -112,8 +136,7 @@
       <div class="draggable-zones-container">
             <div ng-drop="true" ng-drop-success="onDropComplete1($data,$event)">
                 <span class="title">Drop area #1</span>
-
-                <div ng-repeat="obj in droppedObjects1" ng-drag="true" ng-drag-data="obj" ng-drag-success="onDragSuccess1($data,$event)" ng-center-anchor="{{centerAnchor}}">
+                <div ng-repeat="obj in droppedObjects1" class="redbox {{obj.group}}" ng-drag="true" ng-drag-data="obj" ng-drag-success="onDragSuccess1($data,$event)"  ng-drag-clone-group="{{obj.group}}"  ng-drag-scroll="true" scroll-element=".draggable-zones-container">
                     {{obj.name}}
                 </div>
 
@@ -122,7 +145,7 @@
             <div ng-drop="true" ng-drop-success="onDropComplete2($data,$event)">
                 <span class="title">Drop area #2</span>
 
-                <div ng-repeat="obj in droppedObjects2" ng-drag="true" ng-drag-data="obj" ng-drag-success="onDragSuccess2($data,$event)" ng-center-anchor="{{centerAnchor}}">
+                <div ng-repeat="obj in droppedObjects2" class="redbox {{obj.group}}" ng-drag="true" ng-drag-data="obj" ng-drag-success="onDragSuccess2($data,$event)"  ng-drag-clone-group="{{obj.group}}"  ng-drag-scroll="true" scroll-element=".draggable-zones-container">
                     {{obj.name}}
                 </div>
 
@@ -130,7 +153,7 @@
             <div ng-drop="true" ng-drop-success="onDropComplete3($data,$event)">
                 <span class="title">Drop area #3</span>
 
-                <div ng-repeat="obj in droppedObjects3" ng-drag="true" ng-drag-data="obj" ng-drag-success="onDragSuccess3($data,$event)" ng-center-anchor="{{centerAnchor}}">
+                <div ng-repeat="obj in droppedObjects3" class="redbox {{obj.group}}" ng-drag="true" ng-drag-data="obj" ng-drag-success="onDragSuccess3($data,$event)"  ng-drag-clone-group="{{obj.group}}"  ng-drag-scroll="true" scroll-element=".draggable-zones-container">
                     {{obj.name}}
                 </div>
 
@@ -139,7 +162,7 @@
             <div ng-drop="true" ng-drop-success="onDropComplete4($data,$event)">
                 <span class="title">Drop area #4</span>
 
-                <div ng-repeat="obj in droppedObjects4" ng-drag="true" ng-drag-data="obj" ng-drag-success="onDragSuccess4($data,$event)" ng-center-anchor="{{centerAnchor}}">
+                <div ng-repeat="obj in droppedObjects4" class="redbox {{obj.group}}" ng-drag="true" ng-drag-data="obj" ng-drag-success="onDragSuccess4($data,$event)"  ng-drag-clone-group="{{obj.group}}"  ng-drag-scroll="true" scroll-element=".draggable-zones-container">
                     {{obj.name}}
                 </div>
 
@@ -147,7 +170,14 @@
       </div>
       <hr>
 
+      <div ng-drag-clone="" >
+          {{clonedData.name}}
+      </div>
 
+      <div ng-drag-clone="" ng-drag-clone-copy-class="true" ng-drag-clone-copy-html="false" ng-drag-clone-group="special">
+          <p>Mommy always said I'm special !</p>
+          {{clonedData.name}}
+      </div>
 
       </div>
       <footer style="margin-top:2000px;">footer</footer>
@@ -160,7 +190,7 @@
       controller('MainCtrl', function ($scope) {
         $scope.centerAnchor = true;
         $scope.toggleCenterAnchor = function () {$scope.centerAnchor = !$scope.centerAnchor}
-        $scope.draggableObjects = [{name:'one'}, {name:'two'}, {name:'three'}, {name:'four'}, {name: 'five'}, {name:'six'}, {name:'seven'}, {name:'eight'}, {name:'nine'}, {name:'ten'}, {name:'eleven'}, {name:'twelve'}, {name:'thirtheen'}, {name:'fourteen'}, {name:'fifteen'}, {name:'sixteen'}, {name:'seventeen'}, {name:'eighteen'}, {name:'nineteen'}, {name:'twenty'}];
+        $scope.draggableObjects = [{name:'one'}, {name:'two'}, {name:'three', group : "special"}, {name:'four'}, {name: 'five'}, {name:'six'}, {name:'seven'}, {name:'eight'}, {name:'nine'}, {name:'ten'}, {name:'eleven'}, {name:'twelve'}, {name:'thirtheen'}, {name:'fourteen'}, {name:'fifteen'}, {name:'sixteen'}, {name:'seventeen'}, {name:'eighteen'}, {name:'nineteen'}, {name:'twenty'}];
         $scope.droppedObjects1 = [];
         $scope.droppedObjects2= [];
         $scope.droppedObjects3= [];

--- a/example-multiple-scrolls.html
+++ b/example-multiple-scrolls.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>ngDraggable</title>
+  <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootswatch/2.3.1/spruce/bootstrap.min.css">
+  <style>
+
+    *{
+        -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box;
+    }
+    [ng-drag]{
+        -moz-user-select: -moz-none;
+        -khtml-user-select: none;
+        -webkit-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+    }
+    [ng-drag]{
+        width: 100px;
+        height: 100px;
+        background: rgba(255,0,0, 0.5);
+        color:white;
+        text-align: center;
+        padding-top:40px;
+        display: inline-block;
+        margin::0px 10px;
+        cursor: move;
+    }
+    ul.draggable-objects:after{
+        display: block;
+        content:"";
+        clear:both;
+    }
+
+    .draggable-objects
+    {
+      height: 100px;
+      overflow: auto;
+    }
+
+    .draggable-objects li{
+        float:left;
+        display: block;
+        width: 120px;
+        height:100px;
+        margin-bottom: 10px;
+    }
+    [ng-drag].drag-over{
+        border:solid 1px red;
+    }
+    [ng-drag].dragging{
+        opacity: 0.5;
+    }
+    [ng-drop]{
+        background: rgba(0,255,0, 0.5);
+        text-align: center;
+        width: 600px;
+        height: 200px;
+        padding-top:90px;
+        display: block;
+        margin:20px auto;
+        position: relative;
+    }
+    [ng-drop].drag-enter{
+        border:solid 5px red;
+    }
+    [ng-drop] span.title{
+        display: block;
+        position: absolute;
+        top:50%;
+        left:50%;
+        width: 200px;
+        height: 20px;
+        margin-left: -100px;
+        margin-top: -10px;
+    }
+    [ng-drop] div{
+        position: relative;
+        z-index: 2;
+    }
+
+    .draggable-zones-container
+    {
+      height: 400px;
+      width: 555px;
+      overflow: auto;
+      margin: auto;
+    }
+
+    .space
+    {
+      height: 100px;
+
+    }
+  </style>
+</head>
+<body ng-app="ExampleApp">
+
+  <div class="container" ng-controller="MainCtrl">
+
+    <div class="row">
+      <h1>ngDraggable Multiple Scrolls Example</h1>
+    </div>
+      <div class="space"></div>
+        <ul class="draggable-objects">
+            <li  ng-repeat="obj in draggableObjects" >
+                <div ng-drag="true" ng-drag-data="obj" data-allow-transform="true" ng-drag-scroll="true" scroll-element=".draggable-zones-container"> {{obj.name}} </div>
+            </li>
+        </ul>
+
+      <hr/>
+      <div class="draggable-zones-container">
+            <div ng-drop="true" ng-drop-success="onDropComplete1($data,$event)">
+                <span class="title">Drop area #1</span>
+
+                <div ng-repeat="obj in droppedObjects1" ng-drag="true" ng-drag-data="obj" ng-drag-success="onDragSuccess1($data,$event)" ng-center-anchor="{{centerAnchor}}">
+                    {{obj.name}}
+                </div>
+
+            </div>
+
+            <div ng-drop="true" ng-drop-success="onDropComplete2($data,$event)">
+                <span class="title">Drop area #2</span>
+
+                <div ng-repeat="obj in droppedObjects2" ng-drag="true" ng-drag-data="obj" ng-drag-success="onDragSuccess2($data,$event)" ng-center-anchor="{{centerAnchor}}">
+                    {{obj.name}}
+                </div>
+
+            </div>
+            <div ng-drop="true" ng-drop-success="onDropComplete3($data,$event)">
+                <span class="title">Drop area #3</span>
+
+                <div ng-repeat="obj in droppedObjects3" ng-drag="true" ng-drag-data="obj" ng-drag-success="onDragSuccess3($data,$event)" ng-center-anchor="{{centerAnchor}}">
+                    {{obj.name}}
+                </div>
+
+            </div>
+
+            <div ng-drop="true" ng-drop-success="onDropComplete4($data,$event)">
+                <span class="title">Drop area #4</span>
+
+                <div ng-repeat="obj in droppedObjects4" ng-drag="true" ng-drag-data="obj" ng-drag-success="onDragSuccess4($data,$event)" ng-center-anchor="{{centerAnchor}}">
+                    {{obj.name}}
+                </div>
+
+            </div>
+      </div>
+      <hr>
+
+
+
+      </div>
+      <footer style="margin-top:2000px;">footer</footer>
+
+      <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.8/angular.min.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-scroll/1.0.0/angular-scroll.min.js"></script>
+      <script src="ngDraggable.js"></script>
+      <script>
+      angular.module('ExampleApp', ['ngDraggable']).
+      controller('MainCtrl', function ($scope) {
+        $scope.centerAnchor = true;
+        $scope.toggleCenterAnchor = function () {$scope.centerAnchor = !$scope.centerAnchor}
+        $scope.draggableObjects = [{name:'one'}, {name:'two'}, {name:'three'}, {name:'four'}, {name: 'five'}, {name:'six'}, {name:'seven'}, {name:'eight'}, {name:'nine'}, {name:'ten'}, {name:'eleven'}, {name:'twelve'}, {name:'thirtheen'}, {name:'fourteen'}, {name:'fifteen'}, {name:'sixteen'}, {name:'seventeen'}, {name:'eighteen'}, {name:'nineteen'}, {name:'twenty'}];
+        $scope.droppedObjects1 = [];
+        $scope.droppedObjects2= [];
+        $scope.droppedObjects3= [];
+        $scope.droppedObjects4= [];
+        $scope.onDropComplete1=function(data,evt){
+            var index = $scope.droppedObjects1.indexOf(data);
+            if (index == -1)
+            $scope.droppedObjects1.push(data);
+        }
+        $scope.onDragSuccess1=function(data,evt){
+            console.log("133","$scope","onDragSuccess1", "", evt);
+            var index = $scope.droppedObjects1.indexOf(data);
+            if (index > -1) {
+                $scope.droppedObjects1.splice(index, 1);
+            }
+        }
+        $scope.onDragSuccess2=function(data,evt){
+            var index = $scope.droppedObjects2.indexOf(data);
+            if (index > -1) {
+                $scope.droppedObjects2.splice(index, 1);
+            }
+        }
+        $scope.onDragSuccess3=function(data,evt){
+            var index = $scope.droppedObjects3.indexOf(data);
+            if (index > -1) {
+                $scope.droppedObjects3.splice(index, 1);
+            }
+        }
+
+        $scope.onDragSuccess4=function(data,evt){
+            var index = $scope.droppedObjects4.indexOf(data);
+            if (index > -1) {
+                $scope.droppedObjects4.splice(index, 1);
+            }
+        }
+
+        $scope.onDropComplete2=function(data,evt){
+            var index = $scope.droppedObjects2.indexOf(data);
+            if (index == -1) {
+                $scope.droppedObjects2.push(data);
+            }
+        }
+
+        $scope.onDropComplete3=function(data,evt){
+            var index = $scope.droppedObjects3.indexOf(data);
+            if (index == -1) {
+                $scope.droppedObjects3.push(data);
+            }
+        }
+
+        $scope.onDropComplete4=function(data,evt){
+            var index = $scope.droppedObjects4.indexOf(data);
+            if (index == -1) {
+                $scope.droppedObjects4.push(data);
+            }
+        }
+        var inArray = function(array, obj) {
+            var index = array.indexOf(obj);
+        }
+      });
+      </script>
+      </body>
+      </html>

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -108,6 +108,8 @@ angular.module("ngDraggable", [])
                 var onDragStopCallback = $parse(attrs.ngDragStop) || null;
                 var onDragSuccessCallback = $parse(attrs.ngDragSuccess) || null;
                 var allowTransform = angular.isDefined(attrs.allowTransform) ? scope.$eval(attrs.allowTransform) : true;
+                var doFollowMouse = (attrs.ngDragFollow === "false" || attrs.ngDragFollow === false)? false : true;
+
 
                 var getDragData = $parse(attrs.ngDragData);
                 var dragCloneData = {
@@ -115,7 +117,7 @@ angular.module("ngDraggable", [])
                   copyHtml : (attrs.ngDragDCloneCopyHtml === "false" || attrs.ngDragDCloneCopyHtml === false)? false : true,
                   copyClass : (attrs.ngDragCloneCopyClass === "false" || attrs.ngDragCloneCopyClass === false)? false : true,
                   addClass : attrs.ngDragCloneAddClass || null,
-                  hideOnClone :attrs.ngDragCloneHide || true
+                  hideOnClone : (attrs.ngDragCloneHide === "false" || attrs.ngDragCloneHide === false)? false : true
                 };
 
                 // deregistration function for mouse move events in $rootScope triggered by jqLite trigger handler
@@ -316,6 +318,9 @@ angular.module("ngDraggable", [])
                 };
 
                 var moveElement = function (x, y) {
+                    if(!doFollowMouse)
+                      return;
+
                     if(allowTransform) {
                         element.css({
                             transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, ' + x + ', ' + y + ', 0, 1)',


### PR DESCRIPTION
Hi, now when you add the direct ng-drag-scroll. You can add an attribute
"scroll-element"  which contains a jQlite selector. I have also
refactorised the HitTest function.

I know that you're the main fork of this project. But that main project hasn't already accepted your pull request. So I've forked your modification for the touch devices and added the functionality with it and tested it on touch devices. And it works ! :)
